### PR TITLE
【Fixed】チーム機能の修正

### DIFF
--- a/app/controllers/teams/members_controller.rb
+++ b/app/controllers/teams/members_controller.rb
@@ -1,6 +1,14 @@
 class Teams::MembersController < ApplicationController
-  
-  def create; end
+
+  def create
+    if User.find_by(email: params[:team][:email])
+      @user = User.find_by(email: params[:team][:email])
+      Member.create(user_id: @user.id, team_id: params[:team_id])
+      redirect_to team_path(params[:team_id]), notice: 'メンバーを追加しました。'
+    else
+      redirect_to team_path, notice: '招待できませんでした。'
+    end
+  end
 
   def destroy; end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -37,17 +37,6 @@ class TeamsController < ApplicationController
     @team.update(team_params)
   end
 
-  def invitation
-    @team = Team.new(id: params[:id]) #箱@teamを準備 Teamのshowの中で追加できるようにするため、team.idしか入っていない
-    if User.find_by(email: params[:team][:email]) #Userテーブルから入力したmailアドレスがあればtrue
-      @user = User.find_by(email: params[:team][:email]) # そのUser情報を箱@userへ代入
-      Member.create(user_id: @user.id, team_id: @team.id) #Memberテーブルへ保存するためにはuser.idとteam.idがいるため
-      redirect_to team_path
-    else
-      redirect_to team_path, notice: '招待できませんでした。'
-    end
-  end
-
   def secession
     @user = User.find_by(id: params[:user_id])
     @member = Member.find_by(user_id: @user.id, team_id: params[:id])

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -25,7 +25,8 @@
     <% end %>
   <% end %>
 
-<%= form_with(model: @team, method: :post, url: invitation_team_path, local: true) do |form| %>
+<%= form_with model: @team, method: :post, url: team_members_path(@team.id), local: true do |form| %>
+  <%= form.label :招待したい方のEmailアドレスを入力して下さい。 %>
   <%= form.email_field :email %>
   <%= form.submit '招待' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
   resources :users, only: %i[show edit update]
   resources :teams do
     member do
-      post :invitation # member#create
       delete :secession # member#destroy
       patch :owner_change
     end


### PR DESCRIPTION
close #25 

・invitationアクションをcontroller/teams/members_controller.rbのcreateへと移動
・secessionアクションをcontroller/teams/members_controller.rbのdestroyへと移動
・controller/teams/members_controller.rbのcreateのロジックを修正