### PR TITLE
チーム機能　改善・修正点

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,4 +7,11 @@ class Member < ApplicationRecord
   has_many :knowledges, dependent: :destroy
   has_many :stocks, dependent: :destroy
   has_many :stocks_knowledges, through: :stocks, source: :knowledge
+
+  before_create :solo_team?
+
+  def solo_team?
+    @team = Team.find(team_id)
+    throw(:abort) if @team.is_solo == true && @team.members.count == 1
+  end
 end

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -24,10 +24,12 @@
 
 <hr>
 
-<%= form_with model: @team, method: :post, url: team_members_path(@team.id), local: true do |form| %>
-  <%= form.label :招待したい方のEmailアドレスを入力して下さい。 %>
-  <%= form.email_field :email %>
-  <%= form.submit '招待' %>
+<% if @team.is_solo == false %>
+  <%= form_with model: @team, method: :post, url: team_members_path(@team.id), local: true do |form| %>
+    <%= form.label :招待したい方のEmailアドレスを入力して下さい。 %>
+    <%= form.email_field :email %>
+    <%= form.submit '招待' %>
+  <% end %>
 <% end %>
 
 <hr>


### PR DESCRIPTION
close #37 

・オーナー以外はチームへ招待できない設定。teamのeditページへアクセスできない

・チームを個人での利用の場合に、editページで招待フォームを表示させない

・teamのis_soloカラムがtrueの場合でMemberテーブルへ登録処理が来たらrollbackがかかるようにモデルで設定する
view側では制御しているがデータベースへ直接保存はできるため制御した。