### PR TITLE
tips保存時に画像も保存できるようにする

### DIFF
--- a/app/controllers/teams/knowledges/tips_controller.rb
+++ b/app/controllers/teams/knowledges/tips_controller.rb
@@ -55,6 +55,6 @@ class Teams::Knowledges::TipsController < ApplicationController
   private
 
   def tip_params
-    params.require(:tip).permit(:name, :content, pictures_attributes: %i[id tip_id image image_cache]).merge(knowledge_id: params[:knowledge_id],team_id: params[:team_id])
+    params.require(:tip).permit(:name, :content, pictures_attributes: %i[id tip_id image image_cache _destroy]).merge(knowledge_id: params[:knowledge_id],team_id: params[:team_id])
   end
 end

--- a/app/controllers/teams/knowledges/tips_controller.rb
+++ b/app/controllers/teams/knowledges/tips_controller.rb
@@ -12,13 +12,13 @@ class Teams::Knowledges::TipsController < ApplicationController
     @team = Team.find(params[:team_id])
     @knowledge = Knowledge.find(params[:knowledge_id])
     @tip = Tip.new
+    3.times { @tip.pictures.build }
   end
 
   def create
-    @team = Team.find(params[:team_id])
-    @knowledge = Knowledge.find(params[:knowledge_id])
     @member = Member.find_by(user_id: current_user.id, team_id: params[:team_id])
-    @tip = Tip.new(member_id: @member.id, knowledge_id: @knowledge.id, team_id: @team.id, name: params[:tip][:name], content: params[:tip][:content])
+    @tip = Tip.new(tip_params)
+    @tip.member_id = @member.id
     if @tip.save
       redirect_to team_knowledge_tips_path, notice: 'Tipを作成しました。'
     else
@@ -54,6 +54,6 @@ class Teams::Knowledges::TipsController < ApplicationController
   private
 
   def tip_params
-    params.require(:tip).permit(:member_id, :knowledge_id, :team_id, :name, :content)
+    params.require(:tip).permit(:name, :content, pictures_attributes: %i[id tip_id image]).merge(knowledge_id: params[:knowledge_id],team_id: params[:team_id])
   end
 end

--- a/app/controllers/teams/knowledges/tips_controller.rb
+++ b/app/controllers/teams/knowledges/tips_controller.rb
@@ -28,6 +28,7 @@ class Teams::Knowledges::TipsController < ApplicationController
 
   def edit
     @tip = Tip.find(params[:id])
+    @tip.pictures.build
   end
 
   def update
@@ -54,6 +55,6 @@ class Teams::Knowledges::TipsController < ApplicationController
   private
 
   def tip_params
-    params.require(:tip).permit(:name, :content, pictures_attributes: %i[id tip_id image]).merge(knowledge_id: params[:knowledge_id],team_id: params[:team_id])
+    params.require(:tip).permit(:name, :content, pictures_attributes: %i[id tip_id image image_cache]).merge(knowledge_id: params[:knowledge_id],team_id: params[:team_id])
   end
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,3 +1,5 @@
 class Picture < ApplicationRecord
   belongs_to :tip
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,0 +1,3 @@
+class Picture < ApplicationRecord
+  belongs_to :tip
+end

--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -4,4 +4,6 @@ class Tip < ApplicationRecord
   belongs_to :member
   belongs_to :knowledge
   belongs_to :team
+
+  has_many :pictures
 end

--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -5,5 +5,6 @@ class Tip < ApplicationRecord
   belongs_to :knowledge
   belongs_to :team
 
-  has_many :pictures
+  has_many :pictures, dependent: :destroy
+  accepts_nested_attributes_for :pictures
 end

--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -6,5 +6,6 @@ class Tip < ApplicationRecord
   belongs_to :team
 
   has_many :pictures, dependent: :destroy
-  accepts_nested_attributes_for :pictures
+  accepts_nested_attributes_for :pictures, allow_destroy: true
+
 end

--- a/app/views/teams/knowledges/tips/edit.html.erb
+++ b/app/views/teams/knowledges/tips/edit.html.erb
@@ -20,6 +20,12 @@
   <%= form.text_area :content %>
 <br>
 
+<div class='pictures_area'>
+  <% @tip.pictures.each do |picture| %>
+    <%= image_tag picture.image.url, size: '300x200' if picture.image && picture.image.url %>
+  <% end %>
+</div>
+
   <%= form.fields_for :pictures  do |picture| %>
     <%= picture.file_field :image %>
     <%= picture.hidden_field :image_cache %>

--- a/app/views/teams/knowledges/tips/edit.html.erb
+++ b/app/views/teams/knowledges/tips/edit.html.erb
@@ -19,6 +19,12 @@
   <%= form.label :内容 %>
   <%= form.text_area :content %>
 <br>
+
+  <%= form.fields_for :pictures  do |picture| %>
+    <%= picture.file_field :image %>
+    <%= picture.hidden_field :image_cache %>
+  <% end %>
+
   <%= form.submit '登録' %>
 <% end %>
 <br>

--- a/app/views/teams/knowledges/tips/new.html.erb
+++ b/app/views/teams/knowledges/tips/new.html.erb
@@ -19,6 +19,11 @@
   <%= form.label :内容 %>
   <%= form.text_area :content %>
 <br>
+
+  <%= form.fields_for :pictures  do |picture| %>
+    <%= picture.file_field :image %>
+  <% end %>
+
   <%= form.submit '登録' %>
 <% end %>
 <br>

--- a/app/views/teams/knowledges/tips/show.html.erb
+++ b/app/views/teams/knowledges/tips/show.html.erb
@@ -6,7 +6,10 @@
 <hr>
 <h2>内容</h2>
 <p><%= @tip.content %></p>
-
+<h2>画像</h2>
+<% @tip.pictures.each do |picture| %>
+  <%= image_tag picture.image.url, class: 'luminous' %>
+<% end %>
 <hr>
 
 <%= link_to '編集', edit_team_knowledge_tip_path(@team.id, @knowledge.id, @tip.id) %>

--- a/app/views/teams/knowledges/tips/show.html.erb
+++ b/app/views/teams/knowledges/tips/show.html.erb
@@ -8,7 +8,7 @@
 <p><%= @tip.content %></p>
 <h2>画像</h2>
 <% @tip.pictures.each do |picture| %>
-  <%= image_tag picture.image.url %>
+  <%= image_tag picture.image.url, size: '300x200'  if picture.image && picture.image.url %>
 <% end %>
 <hr>
 

--- a/app/views/teams/knowledges/tips/show.html.erb
+++ b/app/views/teams/knowledges/tips/show.html.erb
@@ -8,7 +8,7 @@
 <p><%= @tip.content %></p>
 <h2>画像</h2>
 <% @tip.pictures.each do |picture| %>
-  <%= image_tag picture.image.url, class: 'luminous' %>
+  <%= image_tag picture.image.url %>
 <% end %>
 <hr>
 

--- a/db/migrate/20210724133507_create_pictures.rb
+++ b/db/migrate/20210724133507_create_pictures.rb
@@ -1,0 +1,10 @@
+class CreatePictures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pictures do |t|
+      t.references :tip, foreign_key: true, null: false
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_23_065542) do
+ActiveRecord::Schema.define(version: 2021_07_24_133507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,14 @@ ActiveRecord::Schema.define(version: 2021_07_23_065542) do
     t.index ["team_id"], name: "index_members_on_team_id"
     t.index ["user_id", "team_id"], name: "index_members_on_user_id_and_team_id", unique: true
     t.index ["user_id"], name: "index_members_on_user_id"
+  end
+
+  create_table "pictures", force: :cascade do |t|
+    t.bigint "tip_id", null: false
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tip_id"], name: "index_pictures_on_tip_id"
   end
 
   create_table "stocks", force: :cascade do |t|
@@ -93,6 +101,7 @@ ActiveRecord::Schema.define(version: 2021_07_23_065542) do
   add_foreign_key "knowledges", "teams"
   add_foreign_key "members", "teams"
   add_foreign_key "members", "users"
+  add_foreign_key "pictures", "tips"
   add_foreign_key "stocks", "knowledges"
   add_foreign_key "stocks", "members"
   add_foreign_key "teams", "users"

--- a/spec/factories/pictures.rb
+++ b/spec/factories/pictures.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :picture do
+    tip { nil }
+    image { "MyString" }
+  end
+end

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Picture, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #45 

・登録可能にした fields_for
・newの時点て３つ作成 3.times { @tip.pictures.build }
・三つ目以降は一つずつ追加可能な設定 editで @tip.pictures.build
・tip編集時、画像に対して何もせずupdateをかけると画像データが全て消える tipモデル参照 (これは考える)
・とりあえず登録はできるようにしたので次へ進みたいと思う