### PR TITLE
Alexisからの修正案対応 その３

### DIFF
--- a/app/assets/stylesheets/knowledges.scss
+++ b/app/assets/stylesheets/knowledges.scss
@@ -21,7 +21,7 @@
 .knowledge-show .next-btn {
   background-color: #7db4e6;
 	display: block;
-	margin: 20px 0;
+	margin: 30px 0 0 0;
 	width: 200px;
 }
 
@@ -35,7 +35,7 @@
 	font-weight: bold;
   background-color: #8fbc8f;
 	display: block;
-	margin: 20px 0 0 0;
+	margin: 0 0 20px 0;
 	width: 200px;
 }
 
@@ -106,7 +106,6 @@
 
 
 // ナレッジ削除ボタン
-
 .knowledge-delete-btn {
   margin-left: 30px;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,14 +77,6 @@ class ApplicationController < ActionController::Base
     redirect_to teams_path, notice: 'アクセスできません' if Group.last.id < params[:id].to_i
   end
 
-  def already_exist_team # 同じ名前のチームを作成できない teams
-    @team = current_user.teams.build(team_params)
-    if Team.where(user_id: current_user.id, name: params[:team][:name]).present?
-      flash[:notice] = '既に存在するチーム名です。'
-      render :new
-    end
-  end
-
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def team_function_owner_only #tags
+    @team = Team.find(params[:team_id])
+    return if @team.owner.id == current_user.id
+
+    flash[:notice] = 'チームのオーナーでないとアクセスできません。'
+    redirect_to team_tags_path
+  end
+
   def team_member_check # tags knowledges
     unless Member.where(team_id: params[:team_id]).find_by(user_id: current_user.id).present?
       flash[:notice] = 'メンバーでないのでアクセスできません。'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,16 +5,23 @@ class ApplicationController < ActionController::Base
     user_path(current_user.id)
   end
 
-  def team_members_check # teams
-    unless Member.where(team_id: params[:id]).where(user_id: current_user.id).present?
-      flash[:notice] = 'メンバーではないチーム情報は見れません。'
-      redirect_to teams_path
+  def same_team_check # 同じチームでないUserページにアクセスさせない users
+    if User.find_by(id: params[:id]).nil?
+      redirect_to user_path(current_user), notice: 'ユーザは存在しません。'
+    elsif current_user.id != params[:id].to_i
+      current_user_join_team = current_user.members.pluck('team_id')
+      subject_user = User.find(params[:id]).members.pluck('team_id')
+      same_team_judgment = current_user_join_team + subject_user
+      result = same_team_judgment.select { |judgment| same_team_judgment.count(judgment) > 1 }.uniq
+      unless result.present?
+        redirect_to user_path(current_user), notice: 'チームメンバーではないのでアクセスできません。'
+      end
     end
   end
 
-  def team_member_check # tags knowledges
-    unless Member.where(team_id: params[:team_id]).find_by(user_id: current_user.id).present?
-      flash[:notice] = 'メンバーでないのでアクセスできません。'
+  def team_members_check # teams
+    unless Member.where(team_id: params[:id]).where(user_id: current_user.id).present?
+      flash[:notice] = 'メンバーではないチーム情報は見れません。'
       redirect_to teams_path
     end
   end
@@ -34,7 +41,22 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def tag_check # tips登録時、tag_idsのパラメータがなければtaggingからデータを削除する
+  def knowledge_author_check # knowledges
+    @current_member = Member.find_by(team_id: params[:team_id], user_id: current_user.id)
+    unless @current_member.id == @knowledge.member_id
+      flash[:notice] = 'ナレッジの作成者でないとアクセスできません。'
+      redirect_to team_knowledges_path
+    end
+  end
+
+  def team_member_check # tags knowledges
+    unless Member.where(team_id: params[:team_id]).find_by(user_id: current_user.id).present?
+      flash[:notice] = 'メンバーでないのでアクセスできません。'
+      redirect_to teams_path
+    end
+  end
+
+  def tag_check # tips登録時、tag_idsのパラメータがなければtaggingからデータを削除する tips
     if params[:tip][:tag_ids] == nil
       @tags = Tagging.where(tip_id: @tip.id)
       @tags.each do |tag|
@@ -43,29 +65,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def group_exist # group_idをURLに直接パラメータ入力でアクセスしようとする制限
+  def group_exist # group_idをURLに直接パラメータ入力でアクセスしようとする制限 groups
     redirect_to teams_path, notice: 'アクセスできません' if Group.last.id < params[:id].to_i
   end
 
-  def already_exist_team # 同じ名前のチームを作成できない
+  def already_exist_team # 同じ名前のチームを作成できない teams
     @team = current_user.teams.build(team_params)
     if Team.where(user_id: current_user.id, name: params[:team][:name]).present?
       flash[:notice] = '既に存在するチーム名です。'
       render :new
-    end
-  end
-
-  def same_team_check # 同じチームでないUserページにアクセスさせない
-    if User.find_by(id: params[:id]).nil?
-      redirect_to user_path(current_user), notice: 'ユーザは存在しません。'
-    elsif current_user.id != params[:id].to_i
-      current_user_join_team = current_user.members.pluck('team_id')
-      subject_user = User.find(params[:id]).members.pluck('team_id')
-      same_team_judgment = current_user_join_team + subject_user
-      result = same_team_judgment.select { |judgment| same_team_judgment.count(judgment) > 1 }.uniq
-      unless result.present?
-        redirect_to user_path(current_user), notice: 'チームメンバーではないのでアクセスできません。'
-      end
     end
   end
 

--- a/app/controllers/teams/knowledges_controller.rb
+++ b/app/controllers/teams/knowledges_controller.rb
@@ -2,6 +2,7 @@ class Teams::KnowledgesController < ApplicationController
   before_action :authenticate_user!
   before_action :team_member_check, only: %i[index new create]
   before_action :team_knowledge_check, only: %i[show edit update destroy]
+  before_action :knowledge_author_check, only: :edit
 
   def index
     @team = Team.find(params[:team_id])
@@ -28,8 +29,8 @@ class Teams::KnowledgesController < ApplicationController
   def show
     @team = Team.find(params[:team_id])
     @knowledge = Knowledge.find(params[:id])
-    @member = Member.find_by(team_id: @team.id, user_id: current_user.id)
-    @stock = @member.stocks.find_by(knowledge_id: @knowledge.id)
+    @current_member = Member.find_by(team_id: @team.id, user_id: current_user.id)
+    @stock = @current_member.stocks.find_by(knowledge_id: @knowledge.id)
   end
 
   def edit

--- a/app/controllers/teams/knowledges_controller.rb
+++ b/app/controllers/teams/knowledges_controller.rb
@@ -28,7 +28,7 @@ class Teams::KnowledgesController < ApplicationController
   def show
     @team = Team.find(params[:team_id])
     @knowledge = Knowledge.find(params[:id])
-    @member = Member.find_by(team_id: params[:team_id], user_id: current_user.id)
+    @member = Member.find_by(team_id: @team.id, user_id: current_user.id)
     @stock = @member.stocks.find_by(knowledge_id: @knowledge.id)
   end
 

--- a/app/controllers/teams/tags_controller.rb
+++ b/app/controllers/teams/tags_controller.rb
@@ -15,7 +15,12 @@ class Teams::TagsController < ApplicationController
   def create
     @team = Team.find(params[:team_id])
     @tag = Tag.new(tag_params)
-    if @tag.save
+    @tag.name = @tag.name.tr('０-９ａ-ｚＡ-Ｚ', '0-9a-zA-Z')
+
+    if Tag.find_by(team_id: @team.id, name: @tag.name).present?
+      flash[:notice] = '保存できませんでした。既に存在するタグ名です。'
+      render :new
+    elsif @tag.save
       redirect_to team_tags_path, notice: 'タグを登録しました。'
     else
       render :new

--- a/app/controllers/teams/tags_controller.rb
+++ b/app/controllers/teams/tags_controller.rb
@@ -1,5 +1,6 @@
 class Teams::TagsController < ApplicationController
   before_action :team_member_check
+  before_action :team_function_owner_only, only: :new
 
   def index
     @team = Team.find(params[:team_id])

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -2,7 +2,6 @@ class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :team_owner_check, only: :edit
   before_action :team_members_check, only: :show
-  before_action :already_exist_team, only: :create
 
   def index
     @teams = current_user.members_teams.page(params[:page]).per(6)
@@ -25,8 +24,12 @@ class TeamsController < ApplicationController
 
   def create
     @team = Team.new(team_params)
+    @team.name = @team.name.tr('０-９ａ-ｚＡ-Ｚ', '0-9a-zA-Z')
 
-    if @team.save
+    if Team.find_by(user_id: current_user.id, name: @team.name).present?
+      flash[:notice] = '保存できませんでした。既に存在するチーム名です。'
+      render :new
+    elsif @team.save
       @team.invite_member(@team.user)
       @owner_at_the_member_table = Member.find_by(team_id: @team.id, user_id: current_user.id)
       @group = Group.create

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
+  validates :body, presence: true
+
   belongs_to :member
   belongs_to :group
 

--- a/app/views/teams/groups/show.html.erb
+++ b/app/views/teams/groups/show.html.erb
@@ -48,9 +48,22 @@
 <div class="chat-input">
   <%= form_for @message, url: team_messages_path(@team.id) do |form| %>
     <%= form.hidden_field :group_id, value: @group.id %>
-    <%= form.text_field :body, placeholder: 'メッセージを入力して下さい', class: 'form-control' %>
-    <%= form.submit "投稿する", class: 'message-button' %>
+    <%= form.text_field :body, placeholder: 'メッセージを入力して下さい', class: 'form-control', id: 'input1' %>
+    <%= form.submit "投稿する", class: 'message-button', id: 'button1', disabled: true %>
   <% end %>
 </div>
 
 <%= link_to '戻る', team_path(@team), class: 'btn-flat-logo' %>
+
+
+<script>
+  $("#input1").on("input", function () {
+    var input = $(this).val();
+
+    if (input) {
+      $("#button1").prop('disabled', false);
+    } else {
+      $("#button1").prop('disabled', true);
+    }
+  });
+</script>

--- a/app/views/teams/knowledges/show.html.erb
+++ b/app/views/teams/knowledges/show.html.erb
@@ -10,15 +10,9 @@
 </h1>
 
 <div class="knowledge-show">
-
   <%= link_to team_knowledge_tips_path(@team.id, @knowledge.id), class: 'next-btn btn shine-btn' do %>
     <i class="fa fa-file-text"> ティップ</i>
   <% end %>
-
-  <%= link_to edit_team_knowledge_path(@team, @knowledge), class: 'edit-btn btn' do %>
-    <i class="fa fa-pencil"> ナレッジ編集</i>
-  <% end %>
-
 
   <% if @stock.present? %>
     <%= link_to team_knowledge_stock_path(@knowledge.team_id, @knowledge, params[:id]), method: :delete, class: 'stock-btn sad' do %>
@@ -30,6 +24,11 @@
     <% end %>
   <% end %>
 
+  <% if @knowledge.member_id == @current_member.id %>
+    <%= link_to edit_team_knowledge_path(@team, @knowledge), class: 'edit-btn btn' do %>
+      <i class="fa fa-pencil"> ナレッジ編集</i>
+    <% end %>
+  <% end %>
 </div>
 
 <%= link_to '戻る', team_knowledges_path, class: 'btn-flat-logo' %>

--- a/app/views/teams/members/show.html.erb
+++ b/app/views/teams/members/show.html.erb
@@ -29,12 +29,21 @@
 
 <p class="stock-label">ナレッジストック一覧</p>
 
-<div class="stock-space">
-  <% @stocks.each do |stock| %>
-    <li><%= link_to stock.knowledge.name, team_knowledge_path(@team, stock.knowledge_id) %></li>
+  <% if @current_member.id == params[:id].to_i %>
+    <div class="stock-space">
+      <% @stocks.each do |stock| %>
+        <li><%= link_to stock.knowledge.name, team_knowledge_path(@team, stock.knowledge_id) %></li>
+      <% end %>
+      <%= paginate @stocks %>
+    </div>
+  <% else %>
+    <div class="stock-space">
+      <% @stocks.each do |stock| %>
+        <li><%= stock.knowledge.name %></li>
+      <% end %>
+      <%= paginate @stocks %>
+    </div>
   <% end %>
-  <%= paginate @stocks %>
-</div>
 
 <hr>
 <%= link_to '戻る', team_path(@team), class: 'btn-flat-logo' %>

--- a/app/views/teams/tags/index.html.erb
+++ b/app/views/teams/tags/index.html.erb
@@ -10,15 +10,20 @@
 </h1>
 
 <div>
-  <%= link_to 'タグ登録', new_team_tag_path, class: 'custom-btn new-link' %>
+  <% if @team.owner.id == current_user.id %>
+    <%= link_to 'タグ登録', new_team_tag_path, class: 'custom-btn new-link' %>
+  <% end %>
 </div>
 
 <div class="tag-index">
-    <% @tags.each do |tag| %>
-      <li>
-        <%= tag.name %><%= link_to '削除', team_tag_path(@team, tag), method: :delete, data: { confirm: 'タグを削除しますか？' }, class: 'btn btn-danger' %>
-      </li>
-    <% end %>
+  <% @tags.each do |tag| %>
+    <li>
+      <%= tag.name %>
+      <% if @team.owner.id == current_user.id %>
+        <%= link_to '削除', team_tag_path(@team, tag), method: :delete, data: { confirm: 'タグを削除しますか？' }, class: 'btn btn-danger' %>
+      <% end %>
+    </li>
+  <% end %>
 </div>
 
 <%= paginate @tags %>

--- a/app/views/teams/tags/new.html.erb
+++ b/app/views/teams/tags/new.html.erb
@@ -10,7 +10,7 @@
 </h1>
 
 <%= form_with model: @tag, url: team_tags_path(@team), local: true do |form| %>
-  <div id="error_explanation", style="height:100px;">
+  <div id="error_explanation", style="height:80px;">
     <% if @tag.errors.any? %>
       <h2><%= t('errors.template.header', model: Tag.model_name.human, count: @tag.errors.count) %></h2>
     <ul>

--- a/spec/factories/knowledges.rb
+++ b/spec/factories/knowledges.rb
@@ -5,4 +5,7 @@ FactoryBot.define do
   factory :knowledge2, class: 'Knowledge' do
     name { 'fugaナレッジ' }
   end
+  factory :knowledge3, class: 'Knowledge' do
+    name { 'piyopiyoナレッジ' }
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
-
-RSpec.describe Message, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'メッセージモデル機能', type: :model do
+  describe 'バリデーションのテスト' do
+    context 'メッセージの内容が空の場合' do
+      it 'バリデーションに引っかかる' do
+        user = FactoryBot.create(:user)
+        team = FactoryBot.create(:team, user_id: user.id, owner_id: user.id)
+        member = FactoryBot.create(:member, user_id: user.id, team_id: team.id)
+        group = FactoryBot.create(:group)
+        message = Message.new(body: '', member_id: member.id, group_id: group.id)
+        expect(message).not_to be_valid
+      end
+    end
+    context 'メッセージの内容が入力されているの場合' do
+      it 'バリデーションが通る' do
+        user = FactoryBot.create(:user)
+        team = FactoryBot.create(:team, user_id: user.id, owner_id: user.id)
+        member = FactoryBot.create(:member, user_id: user.id, team_id: team.id)
+        group = FactoryBot.create(:group)
+        message = Message.new(body: 'テストです', member_id: member.id, group_id: group.id)
+        expect(message).to be_valid
+      end
+    end
+  end
 end

--- a/spec/system/knowledge_spec.rb
+++ b/spec/system/knowledge_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe 'ナレッジ機能', type: :system do
     @user2 = FactoryBot.create(:user2)
     @team = FactoryBot.create(:team, user_id: @user.id, owner_id: @user.id)
     @member = FactoryBot.create(:member, user_id: @user.id, team_id: @team.id)
+    @member2 = FactoryBot.create(:member, user_id: @user2.id, team_id: @team.id)
     @group = FactoryBot.create(:group)
+    @knowledge = FactoryBot.create(:knowledge3, member_id: @member2.id, team_id: @team.id)
 
     FactoryBot.create(:team, user: @user, owner: @user)
     FactoryBot.create(:group_member, member: @member, group: @group)
     FactoryBot.create(:knowledge, member: @member, team: @team)
-    FactoryBot.create(:knowledge2, member: @member, team: @team)
+    FactoryBot.create(:knowledge2, member: @member2, team: @team)
 
     visit new_user_session_path
     fill_in 'user[email]', with: 'piyo@piyo.com'
@@ -49,6 +51,19 @@ RSpec.describe 'ナレッジ機能', type: :system do
         click_on '登録'
         expect(page).to have_content 'ナレッジ編集機能テスト'
         expect(page).to have_content 'ナレッジを編集しました。'
+      end
+    end
+    context 'ナレッジ作成者でない場合' do
+      it 'ナレッジ編集ボタンが表示されない' do
+        click_on 'fugaナレッジ'
+        expect(page).not_to have_content 'ナレッジ編集'
+      end
+    end
+    context 'ナレッジ作成者でないかつURLに直接editと入力しアクセスしようとした場合' do
+      it 'ナレッジの一覧画面へリダイレクトされる' do
+        visit edit_team_knowledge_path(@team, @knowledge)
+        expect(page).to have_content 'ナレッジ一覧'
+        expect(page).to have_content 'ナレッジの作成者でないとアクセスできません。'
       end
     end
   end

--- a/spec/system/tag_spec.rb
+++ b/spec/system/tag_spec.rb
@@ -2,26 +2,41 @@ require 'rails_helper'
 RSpec.describe 'タグ機能', type: :system do
   before do
     @user = FactoryBot.create(:user)
+    @user2 = FactoryBot.create(:user2)
     @team = FactoryBot.create(:team, user_id: @user.id, owner_id: @user.id)
     @member = FactoryBot.create(:member, user_id: @user.id, team_id: @team.id)
     @group = FactoryBot.create(:group)
 
+    FactoryBot.create(:member, user: @user2, team: @team)
     FactoryBot.create(:team, user: @user, owner: @user)
     FactoryBot.create(:group_member, member: @member, group: @group)
     FactoryBot.create(:tag, team: @team)
 
-    visit new_user_session_path
-    fill_in 'user[email]', with: 'piyo@piyo.com'
-    fill_in 'user[password]', with: 'piyopiyo'
-    find('.devise-btn').click
-    click_on '個人記録・チーム記録へ'
-    click_on 'テストチーム'
-    click_on 'タグ'
+    def owner
+      visit new_user_session_path
+      fill_in 'user[email]', with: 'piyo@piyo.com'
+      fill_in 'user[password]', with: 'piyopiyo'
+      find('.devise-btn').click
+      click_on '個人記録・チーム記録へ'
+      click_on 'テストチーム'
+      click_on 'タグ'
+    end
+
+    def general
+      visit new_user_session_path
+      fill_in 'user[email]', with: 'fuga@fuga.com'
+      fill_in 'user[password]', with: 'fugafuga'
+      find('.devise-btn').click
+      click_on '個人記録・チーム記録へ'
+      click_on 'テストチーム'
+      click_on 'タグ'
+    end
   end
 
   describe 'タグ登録機能' do
-    context 'タグ登録操作をした場合' do
+    context 'チームオーナーがタグ登録操作をした場合' do
       it 'タグ登録が完了し、タグ一覧画面へ遷移される' do
+        owner
         click_on 'タグ登録'
         fill_in 'tag[name]', with: 'テストタグ'
         click_on '登録'
@@ -29,13 +44,34 @@ RSpec.describe 'タグ機能', type: :system do
         expect(page).to have_content 'タグを登録しました。'
       end
     end
+    context 'オーナー以外がタグ一覧画面へ遷移した場合' do
+      it 'タグ登録ボタンが表示されない' do
+        general
+        expect(page).not_to have_content 'タグ登録'
+      end
+    end
+    context 'オーナーでないかつURLに直接newと入力しアクセスしようとした場合' do
+      it 'タグ一覧画面へリダイレクトされる' do
+        general
+        visit new_team_tag_path(@team)
+        expect(page).to have_content 'タグ一覧'
+        expect(page).to have_content 'チームのオーナーでないとアクセスできません。'
+      end
+    end
   end
   describe 'タグ削除機能' do
-    context 'タグ削除操作をした場合' do
+    context 'チームオーナーがタグ削除操作をした場合' do
       it 'タグ削除が完了する' do
+        owner
         click_on '削除'
         page.accept_alert
         expect(page).not_to have_content 'テストタグ'
+      end
+    end
+    context 'オーナー以外がタグ一覧画面へ遷移した場合' do
+      it 'タグ削除ボタンが表示されない' do
+        general
+        expect(page).not_to have_content '削除'
       end
     end
   end

--- a/spec/system/tag_spec.rb
+++ b/spec/system/tag_spec.rb
@@ -38,10 +38,23 @@ RSpec.describe 'タグ機能', type: :system do
       it 'タグ登録が完了し、タグ一覧画面へ遷移される' do
         owner
         click_on 'タグ登録'
-        fill_in 'tag[name]', with: 'テストタグ'
+        fill_in 'tag[name]', with: 'テストタグ1'
         click_on '登録'
-        expect(page).to have_content 'テストタグ'
+        expect(page).to have_content 'テストタグ1'
         expect(page).to have_content 'タグを登録しました。'
+      end
+    end
+    context 'チームオーナーが既に登録されているタグ名で登録操作をした場合' do
+      it '登録できない' do
+        owner
+        click_on 'タグ登録'
+        fill_in 'tag[name]', with: 'テストタグ1'
+        click_on '登録'
+        click_on 'タグ登録'
+        fill_in 'tag[name]', with: 'テストタグ１'
+        click_on '登録'
+        expect(page).to have_content '保存できませんでした。既に存在するタグ名です。'
+        expect(page).to have_content 'タグ登録'
       end
     end
     context 'オーナー以外がタグ一覧画面へ遷移した場合' do

--- a/spec/system/team_spec.rb
+++ b/spec/system/team_spec.rb
@@ -24,10 +24,22 @@ RSpec.describe 'チーム機能', type: :system do
     context 'チーム登録操作をした場合' do
       it 'チーム登録が完了し、チーム一覧画面へ遷移される' do
         click_on 'チーム登録'
+        fill_in 'team[name]', with: 'テストチーム1'
+        click_on '登録'
+        expect(page).to have_content 'テストチーム1'
+        expect(page).to have_content 'チームを登録しました。'
+      end
+    end
+    context '同名のチーム登録操作をした場合' do
+      it '保存できない' do
+        click_on 'チーム登録'
         fill_in 'team[name]', with: 'テストチーム１'
         click_on '登録'
-        expect(page).to have_content 'テストチーム１'
-        expect(page).to have_content 'チームを登録しました。'
+        click_on 'チーム登録'
+        fill_in 'team[name]', with: 'テストチーム1'
+        click_on '登録'
+        expect(page).to have_content '保存できませんでした。既に存在するチーム名です。'
+        expect(page).to have_content '登録'
       end
     end
   end

--- a/spec/system/team_spec.rb
+++ b/spec/system/team_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe 'チーム機能', type: :system do
         expect(page).to have_content 'チームを登録しました。'
       end
     end
-    context '同名のチーム登録操作をした場合' do
-      it '保存できない' do
+    context '既に登録されているチーム名で登録操作をした場合' do
+      it '登録できない' do
         click_on 'チーム登録'
         fill_in 'team[name]', with: 'テストチーム１'
         click_on '登録'


### PR DESCRIPTION
close #112 

- [x] 個々のチームでメモを作成する場合、メモを追加するためにスクロールする必要がある場合でも、大きな黒いスペースがあります。デザインを修正してください。

→ 個人での利用ではいっその事メッセージ機能は使えない方法でも良いかと考えていました。
しかし私はせっかくなので何らかの形で利用できる様にしたいと考えました。
例えば、
LINEというアプリで自分だけのグループを作成する事ができます。
私はLINEで自分だけのグループを作成しメモとして利用しています。
そういった使い方を想定し、
● チームではチームメッセージ
● 個人ではメモ
という表示がされるように設定しました。
デザインに関しては個人とチームで変えると独創的でとても良いなと感じました。
issuesとしても立てておくので今後の改善案として頂ければと思います。

---

- [x] 訂正ありがとうございます。また、編集機能を追加してください。場合によっては、メッセージを削除したくなくても、何らかの理由でメッセージを編集したいことがあります。

→ 対応する
別ページで行わざるを得ないと考えている・・・
今から非同期処理はとても厳しいな・・・

編集機能ですが、現状私が直ちに取り掛かれる機能を実装しようとすると
editページを作成し編集してからまた戻ってくるような形になります
一つのページで完結させたいと考えていて、この部分は将来的には非同期で色々できる様に実装したいと考えています
今はもし記述内容を間違えた場合、記述内容をコピーし新しく投稿し過去の投稿を削除して頂く形でお願いしたいです
issuesとして立てておくので今後の改善案として頂ければと思います

---

- [x] 空のノートを作成しようとすると、作成できるようなので、空のノートが作成できないように検証を追加してください！空のノートを作成することに意味がないかもしれないからです。

→ ノートなんて機能はないのだが・・・おそらくメッセージ機能での事だろう
バイデーションを設定しよう
エラーメッセージを表示させないといけなくなるので
また表示位置などを考えないといけない

投稿するボタンに disabled: true を入れました
jQueryで「disabled」をつけたり外したりする形にしました。
モデルには presence: :true を入れました
messageのModelSpecを記述しました

---

- [x] また、タグを作成する際に大きな空白がありますが、無駄な空白がないように修正してください。

→ 新規登録する際に３０文字って制限かけてるくせにフォーム長くね？って意味とした修正する

極限まで詰めました。
申し訳ございません。そこの空白はおそらくエラー文字を表示させる為です。
違和感を感じるかも知れませんが、ご理解のほど、よろしくお願いいたします。
将来的にはタグの一覧画面で非同期作成ができるように実装するつもりです。
よろしくお願いいたします。

---

- [x] 同じタグを好きなだけ作成できるようで、同じタグの先端にたくさんのタグを追加しても意味がないと思います！

→ 同名のタグを作成できないように設定する

英数字の半角全角は盲点でした。
tagのcreate時に
@tag.name = @tag.name.tr('０-９ａ-ｚＡ-Ｚ', '0-9a-zA-Z')
if Tag.find_by(team_id: @team.id, name: @tag.name).present?
と設定しました。
保存時に全角から半角に変換する事により、同名で保存されない様に対応しました。
申し訳ございませんが、半角を選択した理由はありません。

---

- [x] 同じチーム名をいくらでも作れるようで、どのチームにチェックインすればいいのか混乱してしまうので修正をお願いします。

→ 英数字の半角全角は盲点だったわwwwwwwクソワロタ
対応したい
意味はないが 半角で統一する

英数字の半角全角は盲点でした。
teamのcreate時に
@team.name = @team.name.tr('０-９ａ-ｚＡ-Ｚ', '0-9a-zA-Z')
if Team.find_by(user_id: current_user.id, name: @team.name).present?
と設定しました。
保存時に全角から半角に変換する事により、同名で保存されない様に対応しました。
申し訳ございませんが、半角を選択した理由はありません。

---

- [x] 自分が作成していないタグを、チームメンバーだからといって削除してもいいのでしょうか？

→ 確かになあ・・・制限するか

メンバーが勝手に削除または余計な作成をしてしまう可能性がありました。
気づいて頂きありがとうございます。
タグへの作成・削除に関してオーナー権限でないとできない仕様にします。
もし削除してしまった場合、責任がオーナーに絞れますし、そもそも早急に必要という物でもないと思いました。
よってチームのオーナーが管理する形にしたいと思います。

・タグはチームのオーナーが管理する形に変更しました。
・チームオーナーだけ一覧画面にて削除ボタンを表示させるようにしました。
・チームオーナー以外がURLに直接newと入力しアクセスする事への制限をかけました。
・メンバーが新たにタグを登録したい場合、オーナーに何らかの形で申請して頂きます。
このアプリで専用の申請などができたら良いなと感じました。
現在は利用者で運用を決めてチームメッセージで申請して頂ければと考えます。

---

- [x] 自分が作成したものではない知識を、チームのメンバーだからといって削除したり編集したりしてもいいのでしょうか？

→ 確かに対策する

メンバーが勝手に削除または編集をしてしまう可能性がありました。
気づいて頂きありがとうございます。
・ナレッジ詳細画面でナレッジ編集ボタンを表示させなくしました。
・ナレッジ作成者以外がURLに直接editと入力しアクセスする事への制限をかけました。

---

- [x] 誰かが在庫を持っていたら、他の誰も在庫を持てないようです。私は在庫を取り消すことができます。誰かの気持ちを変えても大丈夫ですか？

→ いや、皆んながそれぞれストックできるはず
混乱させるseedを作成してしまったか？確認する

チームメンバーがそれぞれストックしたい項目をストックできます。
メンバーがストックしている一覧からそのページへ遷移する事は可能ですが
誰かのストックしている状態を変更する仕組みにはなっていないはずです。
混乱させてしまって申し訳ございません。
メンバー詳細ページにおいて
自分のメンバーページのshow画面だとリンクを表示させて
他のメンバーページのshow画面ではリンク化せず何をストックしているのか表示させる様にしました。

---

- [x] 他のヒントが表示されないように制限されていますか？同じチームにいても？

→ これは前回対策したはず、確認する

確認しましたが、正常にナレッジに対してのティップしか表示されていませんでした。
前回の提出との間で何度か調整したので、
エラーに気づき修正する前の状態を見てしまったかも知れません。