### PR TITLE
チームの編集機能修正

### DIFF
--- a/app/assets/stylesheets/teams.scss
+++ b/app/assets/stylesheets/teams.scss
@@ -70,7 +70,7 @@
 // チーム作成時のチームか個人か選択時のラジオボタンアニメーション
 .cp_ipradio {
 	width: 90%;
-	margin: 2em auto;
+	margin: 2em 0;
 	text-align: left;
 }
 @keyframes click-wave {

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -18,13 +18,25 @@
   <%= form.label :チーム名 %>
   <%= form.text_field :name, class: 'form-control', placeholder: 'チーム名を入力して下さい。' %>
 
-  <div class="cp_ipradio">
-    <%= form.label :is_solo, '個人', value: true %>
-    <%= form.radio_button :is_solo, true, class: 'option-input radio' %>
-
-    <%= form.label :is_solo, 'チーム', value: false %>
-    <%= form.radio_button :is_solo, false, class: 'option-input radio' %>
-  </div>
+  <% if controller.action_name == 'edit' %>
+    <% if @team.members.count == 1 %>
+      <div class="cp_ipradio">
+        <div><%= form.label :使用用途 %></div>
+        <%= form.label :is_solo, '個人', value: true %>
+        <%= form.radio_button :is_solo, true, class: 'option-input radio' %>
+        <%= form.label :is_solo, 'チーム', value: false %>
+        <%= form.radio_button :is_solo, false, class: 'option-input radio' %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="cp_ipradio">
+      <div><%= form.label :使用用途 %></div>
+      <%= form.label :is_solo, '個人', value: true %>
+      <%= form.radio_button :is_solo, true, class: 'option-input radio' %>
+      <%= form.label :is_solo, 'チーム', value: false %>
+      <%= form.radio_button :is_solo, false, class: 'option-input radio' %>
+    </div>
+  <% end %>
 
   <%= form.submit I18n.t('views.button.register'), class: 'custom-btn new-link' %>
 </div>

--- a/spec/factories/group_members.rb
+++ b/spec/factories/group_members.rb
@@ -3,4 +3,8 @@ FactoryBot.define do
     member { "" }
     group { "" }
   end
+  factory :group_member2, class: 'GroupMember' do
+    member { "" }
+    group { "" }
+  end
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -2,4 +2,7 @@ FactoryBot.define do
   factory :group do
     is_dm { false }
   end
+  factory :group2, class: 'Group' do
+    is_dm { false }
+  end
 end

--- a/spec/system/team_spec.rb
+++ b/spec/system/team_spec.rb
@@ -61,6 +61,23 @@ RSpec.describe 'チーム機能', type: :system do
         expect(page).to have_content '編集テスト'
       end
     end
+    context 'チームメンバーが1人で編集画面に遷移した場合' do
+      it '使用用途を更新するフォームが表示される' do
+        click_on 'テストチーム'
+        click_on 'チーム編集'
+        expect(page).to have_content '使用用途'
+      end
+    end
+    context 'チームメンバーが複数人で編集画面に遷移した場合' do
+      it '使用用途を更新するフォームが表示されない' do
+        click_on 'テストチーム'
+        click_on 'チーム編集'
+        fill_in 'team[email]', with: 'fuga@fuga.com'
+        click_on '招待'
+        click_on 'チーム編集'
+        expect(page).not_to have_content '使用用途'
+      end
+    end
   end
   describe 'チーム削除機能' do
     context 'チーム削除操作をした場合' do


### PR DESCRIPTION
メンバーが1人の時は、使用用途の更新を可能にする設定
複数人居る状態で個人での使用に変更できる事はおかしいから設定

close #119 