### PR TITLE
修正：テスト時サイドバーが展開されるように設定 #129

### DIFF
--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'ユーザ機能', type: :system do
         fill_in 'user[email]', with: 'piyo@piyo.com'
         fill_in 'user[password]', with: 'piyopiyo'
         find('.devise-btn').click
+        find('#sidebar-btn').click
         click_on 'ログアウト'
         expect(page).to have_content 'ログアウトしました。'
       end


### PR DESCRIPTION
## issue
close #129

## 目的
アプリの動作を保証する物として修正しないといけない。

## 内容
・助言通り本アプリをcloneし動作する所まで設定
・テスト時、サイドバーを開く事ができていないのでログアウトボタンが押せずエラーが発生していた。
・find('#sidebar-btn').click を記述する事で正常に動作した。
・テスト時、ローカルではscssがきちんと反映されていない状態であった。
適応方法を調査していたが、まだ見つけられていない。引き続き調査する。

## 確認手順

1 | git clone git@github.com:YuyaYamada0721/original_Reco.git
-- | --
2 | bundle install
3 | bin/rake db:migrate:reset    
4 | yarn add bootstrap@4    
5 | bundle exec rspec spec/system/user_spec.rb
