### PR TITLE
メッセージ画面のデザイン調整 #143

### DIFF
--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,41 +1,21 @@
 // 親枠
 .chat-content {
-  display: flex;
-}
-
-// 子枠 参加者
-.chat-member {
-  width: 30%;
-}
-
-.chat-member p {
-  margin-top: 20px;
-  font-size: 1.2rem;
-}
-
-// 子枠 チャット
-.chat-field {
   height: 600px;
-  width: 70%;
   overflow-y: auto;
-}
-
-// 子枠 チャット 内部 投稿者欄
-.chat-name {
-  // width: 15%;
-  // margin-right: 50px;
+  background-color: #f8f9fa;
 }
 
 // チャット内容
 .message-text {
   background-color: blanchedalmond;
-  width: 70%;
+  width: 80%;
   border-radius: 5px;
 }
 
 // 既読のステータス
 .chat-status {
-  width: 30%;
+  width: 20%;
+  font-size: 0.8rem;
 }
 
 // 入力欄
@@ -62,4 +42,35 @@
 
 .chat-status .fa a {
   text-decoration: none;
+}
+
+
+// モーダルウィンドウでメンバー一覧表示
+.member-list {
+    padding: 20px;
+    text-align: right;
+}
+.modal{
+    display: none;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    width: 100%;
+}
+.modal__bg{
+    background: rgba(0,0,0,0.8);
+    height: 100vh;
+    position: absolute;
+    width: 100%;
+}
+.modal__content{
+    background: #fff;
+    left: 50%;
+    padding: 40px;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%,-50%);
+    width: 60%;
+    height: 300px;
+    overflow-y: auto;
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,47 +1,62 @@
 // 親枠
-.chat-content {
+.message-content {
   height: 600px;
   overflow-y: auto;
   background-color: #f8f9fa;
+  border: 5px solid #eee;
+  border-radius: 10px;
 }
 
-// チャット内容
+// メッセージ内容
 .message-text {
-  background-color: blanchedalmond;
+  border: 5px solid #eee;
+  border-radius: 10px;
+  background-color: white;
+  color: #094067;
   width: 80%;
   border-radius: 5px;
 }
 
+// メッセージ投稿者の名前
+.message-name {
+  color: #094067;
+}
+
 // 既読のステータス
-.chat-status {
+.message-status {
   width: 20%;
   font-size: 0.8rem;
+  margin: 0 0 0 10px;
+}
+
+.message-status .fa {
+  color: #094067;
+  font-size: 1.2rem;
+}
+
+.message-status .fa a {
+  text-decoration: none;
 }
 
 // 入力欄
-.chat-input {
+.message-input {
   margin: auto;
   text-align: center;
 }
 
-.chat-input .form-control {
+.message-input .form-control {
   width: 600px;
+  border-radius: 5px;
   display: inline-block;
-  margin: 40px 0 0 0;
+  margin: 10px 0 10px 0;
 }
 
 .message-button {
+  background-color: white;
+  border: 2px solid;
+  border-radius: 5px;
   display: inline-block;
-}
-
-.chat-status .fa {
-  color: red;
-  font-size: 1.2rem;
-  font-weight: bold;
-}
-
-.chat-status .fa a {
-  text-decoration: none;
+  width: 8%;
 }
 
 
@@ -87,7 +102,7 @@
   border: 2px solid #094067;
   font-weight: bold;
   background: white;
-  padding: 10px 10px;
+  padding: 5px 10px;
   border-radius: 6px;
   transition: .3s;
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -9,12 +9,17 @@
 
 // メッセージ内容
 .message-text {
+  width: 80%;
   border: 5px solid #eee;
   border-radius: 10px;
   background-color: white;
   color: #094067;
-  width: 80%;
   border-radius: 5px;
+}
+
+.message-text p {
+  font-size: 1rem;
+  margin: 0;
 }
 
 // メッセージ投稿者の名前
@@ -45,24 +50,24 @@
 }
 
 .message-input .form-control {
-  width: 600px;
+  width: 50%;
   border-radius: 5px;
   display: inline-block;
   margin: 10px 0 10px 0;
 }
 
 .message-button {
-  background-color: white;
+  width: 8%;
   border: 2px solid;
   border-radius: 5px;
+  background-color: white;
   display: inline-block;
-  width: 8%;
 }
 
 
 // モーダルウィンドウでメンバー一覧表示
 .member-list {
-  padding: 20px;
+  padding: 10px;
   text-align: right;
 }
 

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -47,30 +47,52 @@
 
 // モーダルウィンドウでメンバー一覧表示
 .member-list {
-    padding: 20px;
-    text-align: right;
+  padding: 20px;
+  text-align: right;
 }
-.modal{
-    display: none;
-    height: 100vh;
-    position: fixed;
-    top: 0;
-    width: 100%;
+
+.modal {
+  display: none;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  width: 100%;
 }
-.modal__bg{
-    background: rgba(0,0,0,0.8);
-    height: 100vh;
-    position: absolute;
-    width: 100%;
+.modal__bg {
+  position: absolute;
+  background: rgba(0,0,0,0.8);
+  height: 100vh;
+  width: 100%;
 }
 .modal__content{
-    background: #fff;
-    left: 50%;
-    padding: 40px;
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%,-50%);
-    width: 60%;
-    height: 300px;
-    overflow-y: auto;
+  position: absolute;
+  background: #fff;
+  top: 50%;
+  left: 50%;
+  padding: 40px;
+  width: 30%;
+  height: 60%;
+  border-radius: 10px;
+  transform: translate(-50%,-50%);
+  overflow-y: auto;
+}
+
+.js-modal-close {
+  position: absolute;
+  bottom: 20px;
+}
+
+.js-modal-open {
+  color: #094067;
+  border: 2px solid #094067;
+  font-weight: bold;
+  background: white;
+  padding: 10px 10px;
+  border-radius: 6px;
+  transition: .3s;
+}
+.js-modal-open:hover {
+  opacity: 0.6;
+  text-decoration: none;
+  color: #094067;
 }

--- a/app/assets/stylesheets/knowledges.scss
+++ b/app/assets/stylesheets/knowledges.scss
@@ -21,8 +21,8 @@
 }
 
 .knowledge-index-box .card:before{
-	border-top: 5px solid #498ee0;	/* 一部だけ異なる線の太さ・種類・色 */
-	border-left: 5px solid #498ee0;	/* 一部だけ異なる線の太さ・種類・色 */
+	border-top: 5px solid #498ee0;
+	border-left: 5px solid #498ee0;	
 	content: '';
 	display: block;
 	position: absolute;

--- a/app/views/teams/groups/show.html.erb
+++ b/app/views/teams/groups/show.html.erb
@@ -13,15 +13,21 @@
     <% end %>
 </h1>
 
-<div class="chat-content">
-  <div class="chat-member">
-    <p>-参加者-</p>
-    <% @group_members.each do |gm| %>
-      <p><%= gm.member.user.username%></p>
-    <% end %>
-    <%= paginate @group_members %>
-  </div>
+<div class="member-list">
+  <a class="js-modal-open" href="">参加者一覧 <%= @group_members.count %> 人</a>
+</div>
+<div class="modal js-modal">
+  <div class="modal__bg js-modal-close"></div>
+    <div class="modal__content">
+      <p>参加者</p>
+      <% @group_members.each do |gm| %>
+        <p><i class="fa fa-user"></i> <%= gm.member.user.username%></p>
+      <% end %>
+      <a class="js-modal-close" href="">閉じる</a>
+    </div>
+</div>
 
+<div class="chat-content">
   <div class="chat-field">
     <% @messages.each do |message| %>
     <div class="chat bg-light p-4">
@@ -37,7 +43,7 @@
               <span>既読 <%= message.reads.where(is_checked: true).count %> / <%= message.reads.count %></span>
             <% end %>
         <% end %>
-          <div><%= l message.created_at %></div>
+        <div><%= l message.created_at %></div>
         </div>
       </div>
     </div>
@@ -65,5 +71,17 @@
     } else {
       $("#button1").prop('disabled', true);
     }
+  });
+
+
+  $(function(){
+    $('.js-modal-open').on('click',function(){
+        $('.js-modal').fadeIn();
+        return false;
+    });
+    $('.js-modal-close').on('click',function(){
+        $('.js-modal').fadeOut();
+        return false;
+    });
   });
 </script>

--- a/app/views/teams/groups/show.html.erb
+++ b/app/views/teams/groups/show.html.erb
@@ -33,7 +33,7 @@
     <div class="chat bg-light p-4">
       <div class="message-name"><span><%= message.member.user.username %></span></div>
       <div class="message d-flex flex-row align-items-start mb-3">
-        <div class="message-text p-2 ms-2 mb-0"><%= message.body %></div>
+        <div class="message-text p-2 ms-2 mb-0"><%= markdown(message.body).html_safe %></div>
         <div class="message-status">
         <% if message.member_id == @current_member.id %>
           <%= link_to team_message_path(@team.id, message), method: :delete, data: { confirm: 'メッセージを削除しますか？' } do%>
@@ -54,7 +54,7 @@
 <div class="message-input">
   <%= form_for @message, url: team_messages_path(@team.id) do |form| %>
     <%= form.hidden_field :group_id, value: @group.id %>
-    <%= form.text_field :body, placeholder: 'メッセージを入力して下さい。', class: 'form-control', id: 'input-message' %>
+    <%= form.text_area :body, placeholder: 'メッセージを入力して下さい。', class: 'form-control', id: 'input-message' %>
     <%= form.button class: 'message-button', id: 'button1', disabled: true do %>
       <i class="fa fa-paper-plane-o"> 送信</i>
     <% end %>

--- a/app/views/teams/groups/show.html.erb
+++ b/app/views/teams/groups/show.html.erb
@@ -27,14 +27,14 @@
     </div>
 </div>
 
-<div class="chat-content">
+<div class="message-content">
   <div class="chat-field">
     <% @messages.each do |message| %>
     <div class="chat bg-light p-4">
-      <div class="chat-name"><span><%= message.member.user.username %></span></div>
+      <div class="message-name"><span><%= message.member.user.username %></span></div>
       <div class="message d-flex flex-row align-items-start mb-3">
         <div class="message-text p-2 ms-2 mb-0"><%= message.body %></div>
-        <div class="chat-status">
+        <div class="message-status">
         <% if message.member_id == @current_member.id %>
           <%= link_to team_message_path(@team.id, message), method: :delete, data: { confirm: 'メッセージを削除しますか？' } do%>
             <i class="fa fa-trash-o"></i>
@@ -51,11 +51,13 @@
   </div>
 </div>
 
-<div class="chat-input">
+<div class="message-input">
   <%= form_for @message, url: team_messages_path(@team.id) do |form| %>
     <%= form.hidden_field :group_id, value: @group.id %>
-    <%= form.text_field :body, placeholder: 'メッセージを入力して下さい', class: 'form-control', id: 'input1' %>
-    <%= form.submit "投稿する", class: 'message-button', id: 'button1', disabled: true %>
+    <%= form.text_field :body, placeholder: 'メッセージを入力して下さい。', class: 'form-control', id: 'input-message' %>
+    <%= form.button class: 'message-button', id: 'button1', disabled: true do %>
+      <i class="fa fa-paper-plane-o"> 送信</i>
+    <% end %>
   <% end %>
 </div>
 
@@ -63,7 +65,7 @@
 
 
 <script>
-  $("#input1").on("input", function () {
+  $("#input-message").on("input", function () {
     var input = $(this).val();
 
     if (input) {

--- a/app/views/teams/groups/show.html.erb
+++ b/app/views/teams/groups/show.html.erb
@@ -9,7 +9,7 @@
     <% if @team.is_solo? %>
       メモ
     <% else %>
-    <%= @team.name %> -メッセージ-
+    <%= @team.name %> <i class="fa fa-caret-right"></i> メッセージ
     <% end %>
 </h1>
 


### PR DESCRIPTION
## issue
close #143

## 目的
視覚的に認識しやすくする。

## 内容
・group show での画面全体のデザイン調整
・現在地の表示デザイン
・メッセージマークダウン入力設定
・メッセージ表示調整
・参加者メンバー一覧をモーダル表示

## 確認手順
・チーム詳細からチームメッセージで確認可能
・参加者一覧を押下することでモーダル表示
・マークダウンで入力してみる