### PR TITLE
チームメンバーページの更新 

### DIFF
--- a/app/assets/stylesheets/members.scss
+++ b/app/assets/stylesheets/members.scss
@@ -1,24 +1,38 @@
-.chat-btn-space .solo-chat-btn {
-  color: white;
-  background-color: #ffb6c1;
-	display: block;
-	margin: 20px 0;
-	width: 200px;
+.member-profile-bio {
+  color: #094067;
+  font-size: 1.3rem;
 }
 
-.stock-space {
-  height: 500px;
+.profile-real-name {
+  color: #094067;
+  font-size: 1.2rem;
 }
 
 .stock-space li {
-  margin: 20px 0;
-  font-size: 1.2rem;
+  margin: 10px 0;
+  font-size: 1rem;
+}
+
+.profile-stock p {
+  font-size: 1.1rem;
 }
 
 .stock-space a {
   text-decoration: none;
 }
 
-.chat-btn-space .fa {
-  font-weight: bold;
+.profile-stock {
+    border-top: #666 5px dotted;
+    margin-top: 2rem;
+    padding-top: 2rem;
+}
+
+.profile-stock {
+    float: right;
+    width: calc(66.666% - 2rem);
+}
+
+.profile-return {
+    float: left;
+    width: calc(66.666% - 2rem);
 }

--- a/app/controllers/teams/members_controller.rb
+++ b/app/controllers/teams/members_controller.rb
@@ -36,7 +36,7 @@ class Teams::MembersController < ApplicationController
     @member_group_member = GroupMember.where(member_id: @member.id) #対象のメンバーのグループ情報
     @current_member = Member.find_by(team_id: params[:team_id], user_id: current_user.id) #現在のユーザのメンバーとしての情報
     @current_member_group_member = GroupMember.where(member_id: @current_member.id) #現在のユーザのメンバーとしてのグループ情報
-    @stocks = Stock.where(member_id: params[:id]).page(params[:page]).per(10) #メンバーでの画面でストック一覧を表示させるため
+    @stocks = Stock.where(member_id: params[:id]).page(params[:page]).per(5) #メンバーでの画面でストック一覧を表示させるため
 
     unless @member.id == @current_member.id
       @current_member_group_member.each do |cmgm|

--- a/app/views/teams/members/show.html.erb
+++ b/app/views/teams/members/show.html.erb
@@ -6,28 +6,46 @@
       Team Member
     <% end %>
   </span>
-  <%= @team.name %> -<%= @member.user.username %>-
+  <%= @team.name %> <i class="fa fa-caret-right"></i> <%= @member.user.username %>
 </h1>
 
-<div class="chat-btn-space">
-  <% if @member.id == @current_member.id %>
-  <% else %>
-    <% if @is_group == true %>
-      <%= link_to team_group_path(params[:team_id], @group_id), class: 'solo-chat-btn btn' do %>
-        <i class="fa fa-comment"> メッセージへ</i>
-      <% end %>
-    <% else %>
-      <%= form_for @group, url: team_groups_path(params[:team_id])  do |f| %>
-        <%= fields_for @group_member do |e| %>
-          <%= e.hidden_field :member_id, value: @member.id %>
-        <% end %>
-        <%= f.submit "メッセージを始める", class: 'solo-chat-btn btn' %>
-      <% end %>
-    <% end %>
-  <% end %>
+<div class="profile-image">
+  <%= image_tag @member.user.image.url, size: '400x300' if @member.user.image && @member.user.image.url %>
 </div>
 
-<p class="stock-label">ナレッジストック一覧</p>
+<div class="profile-user-settings">
+  <h2 class="profile-user-name"><%= @member.user.username %></h2>
+</div>
+
+<div class="profile-stats">
+  <ul>
+    <li>
+      <% if @member.id == @current_member.id %>
+      <% else %>
+        <% if @is_group == true %>
+          <%= link_to team_group_path(params[:team_id], @group_id), class: 'btn user-show-btn' do %>
+            メッセージへ
+          <% end %>
+        <% else %>
+          <%= form_for @group, url: team_groups_path(params[:team_id])  do |f| %>
+            <%= fields_for @group_member do |e| %>
+              <%= e.hidden_field :member_id, value: @member.id %>
+            <% end %>
+            <%= f.submit "メッセージを始める", class: 'btn user-show-btn' %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </li>
+  </ul>
+</div>
+
+<div class="profile-bio">
+  <p class="member-profile-bio"><i class="fa fa-flag"></i> 自己紹介</p>
+  <span class="profile-real-name"><%= @member.user.introduction %></span>
+</div>
+
+<div class="profile-stock">
+  <p class="stock-label"><i class="fa fa-star"></i> ナレッジストック一覧</p>
 
   <% if @current_member.id == params[:id].to_i %>
     <div class="stock-space">
@@ -44,6 +62,8 @@
       <%= paginate @stocks %>
     </div>
   <% end %>
+</div>
 
-<hr>
-<%= link_to '戻る', team_path(@team), class: 'btn-flat-logo' %>
+<div class="profile-return">
+  <%= link_to '戻る', team_path(@team), class: 'btn-flat-logo' %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="profile-bio">
-    <p><span class="profile-real-name"><%= @user.introduction %></p>
+    <p><span><%= @user.introduction %></span></p>
   </div>
 
 </div>


### PR DESCRIPTION
## issue
close #118

## 目的
この調整をしないと自己紹介や画像の設定が意味のない物になるから。

## 内容
・ユーザー詳細ページを参考に調整した。
・ストックした物も正常に表示されるようにしている。

## 確認手順
・チームを作成し、メンバーを招待して、メンバーのページに行くと確認可能
・自分のストックはリンク化、他のストックは参照のみ
※ 実際このアプリを体験してくれたアレクシスが「これストック機能うまく動作してなくね？」と
迷ってしまっていたので上記のように設定した。
