### PR TITLE
チーム詳細画面調整とそれに関係するデザインの調整

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -125,3 +125,21 @@ body {
 ::placeholder {
   font-size: 0.8rem;
 }
+
+
+// カードにホバーすると傾く
+.stacked--fan-right {
+	transform-origin: center bottom;
+
+	&:before,
+	&:after {
+			transform-origin: 50% 100%;
+	}
+
+	&:hover {
+			transform: translate(2.5px, 0) rotate(2.5deg);
+
+			&:before { transform: translate(-2.5px, 0) rotate(-2.5deg); }
+			&:after { transform: translate(-5px, 0) rotate(-5deg); }
+	}
+}

--- a/app/assets/stylesheets/knowledges.scss
+++ b/app/assets/stylesheets/knowledges.scss
@@ -55,7 +55,7 @@
 // -----
 
 
-// ナレッジ詳細のボタン
+// ナレッジ詳細でのボタン
 .knowledge-show-button {
   display: flex;
   justify-content: space-between;

--- a/app/assets/stylesheets/knowledges.scss
+++ b/app/assets/stylesheets/knowledges.scss
@@ -11,7 +11,6 @@
 .knowledge-index-box {
   background-color: #f8f9fa;
   height: 480px;
-  // height: auto;
 }
 
 .knowledge-index-box .card {
@@ -22,7 +21,7 @@
 
 .knowledge-index-box .card:before{
 	border-top: 5px solid #498ee0;
-	border-left: 5px solid #498ee0;	
+	border-left: 5px solid #498ee0;
 	content: '';
 	display: block;
 	position: absolute;
@@ -53,48 +52,48 @@
 .form-knowledge .form-control {
   width: 400px;
 }
+// -----
 
-.knowledge-show .next-btn {
-  background-color: #7db4e6;
-	display: block;
-	margin: 30px 0 0 0;
-	width: 200px;
+
+// ナレッジ詳細のボタン
+.knowledge-show-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px 0;
+  padding: 1em 2em;
+  width: 300px;
+  color: #2285b1;
+  font-size: 1.2rem;
+  border: 2px solid #a0c4d3;
+  border-radius: 10px;
 }
 
-.knowledge-show .fa {
-  color: white;
-	font-weight: bold;
+.knowledge-show-button::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-top: 3px solid #2285b1;
+  border-right: 3px solid #2285b1;
+  transform: rotate(45deg);
 }
 
-.knowledge-show .edit-btn {
-  color: white;
-	font-weight: bold;
-  background-color: #8fbc8f;
-	display: block;
-	margin: 0 0 20px 0;
-	width: 200px;
+.knowledge-show-button:hover {
+  color: #333333;
+  text-decoration: none;
+  background-color: #a0c4d3;
 }
 
-
-// ストックボタン
-.knowledge-show .stock-btn {
-  color: white;
-  background-color: #b2b2ff;
-	border-radius: 5px;
-	padding: 10px;
-	margin: 20px 0;
-	width: 200px;
+.knowledge-show-button:hover::after {
+  border-top: 3px solid #333333;
+  border-right: 3px solid #333333;
 }
+// -----
 
+
+// ストックボタン(浮く)嬉しさを表現
 .knowledge-show .fine {
-  color: #fff;
-  font-weight: bold;
-  text-align: center;
-  background: #b2b2ff;
-  border-radius: 5px;
   position: relative;
-  z-index: 1;
-  display: inline-block;
   transition: .3s;
 }
 
@@ -119,15 +118,10 @@
   transform: translateY(7px);
   opacity: 1;
 }
+// -----
 
 
-// ストック解除
-.knowledge-show .sad {
-  text-align: center;
-  font-weight: bold;
-  display: inline-block;
-}
-
+// ストック解除アニメーション(震える)悲しさを表現
 .knowledge-show .sad:hover {
   animation: hurueru .3s  infinite;
 }
@@ -139,9 +133,11 @@
   75% {transform: translate(2px, 0px) rotateZ(-1deg)}
   100% {transform: translate(0px, 0px) rotateZ(0deg)}
 }
+// -----
 
 
 // ナレッジ削除ボタン
 .knowledge-delete-btn {
   margin-left: 30px;
 }
+// -----

--- a/app/assets/stylesheets/teams.scss
+++ b/app/assets/stylesheets/teams.scss
@@ -118,67 +118,104 @@
 
 
 // チーム詳細時の大枠
-.team-show-function {
+.team-show {
 	display: flex;
-	height: 400px;
-	margin: 50px 0;
-}
-
-.team-member-index {
-	margin-right: 80px;
+	height: 650px;
+	margin: 50px 0 0 0;
 }
 
 
 // チームメンバー一覧
-.team-show-li {
-	width: 400px;
-	margin: 30px 0px;
-	font-size: 1.2rem;
-	list-style: none;
+.team-show-member {
+	margin: 0 50px 0 50px;
 }
 
-.team-show-li .fa {
-	margin-right: 20px;
+.team-show-member img{
+	height: 80px;
+	width: 80px;
+	border-radius: 50%;
+}
+
+.team-show-member p{
+	margin-top: 5px;
+	font-size: 1rem;
+}
+
+.team-show-member .pagination {
+	margin-left: 50px;
+}
+
+// メンバー名前
+.member-button {
+  align-items: center;
+  margin: 0 0 0 20px;
+  padding: 1em 2em;
+  width: auto;
+  color: #2285b1;
+  font-weight: 500;
+	border: 1px solid #a0c4d3;
+  border-radius: 10px;
+  box-shadow: 5px 5px 0 #3d9ec8;
+  transition: 0.3s;
+}
+
+.member-button:hover {
+  text-decoration: none;
+  background-color: #a0c4d3;
+  box-shadow: 0 0 0;
+}
+// -----
+
+.team-show-li {
+	margin: 20px 0px;
+	font-size: 1.2rem;
+	list-style: none;
 }
 
 .team-show-li a {
 	text-decoration: none;
 }
 
-.team-show {
-	margin-left: 100px;
+// チーム詳細の機能
+.team-show-function {
+	margin: 30px 50px 0 50px;
+}
+// _____
+
+// チーム詳細のボタン
+.team-show-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px 0;
+  padding: 1em 2em;
+  width: 300px;
+  color: #2285b1;
+  font-size: 1.2rem;
+  border: 2px solid #a0c4d3;
+  border-radius: 10px;
 }
 
-.team-show .next-btn {
-  background-color: #7db4e6;
-	display: block;
-	margin: 20px 0;
-	width: 200px;
+.team-show-button::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-top: 3px solid #2285b1;
+  border-right: 3px solid #2285b1;
+  transform: rotate(45deg);
 }
 
-.team-show .fa {
-  color: white;
-	font-weight: bold;
+.team-show-button:hover {
+  color: #333333;
+  text-decoration: none;
+  background-color: #a0c4d3;
 }
 
-.team-show .edit-btn {
-  color: white;
-	font-weight: bold;
-  background-color: #8fbc8f;
-	display: block;
-	margin: 20px 0;
-	width: 200px;
+.team-show-button:hover::after {
+  border-top: 3px solid #333333;
+  border-right: 3px solid #333333;
 }
-
-.team-show .message-btn {
-  color: white;
-	font-weight: bold;
-  background-color: #ffb6c1;
-	display: block;
-	margin: 20px 0;
-	width: 200px;
-}
-
+// -----
 
 // チーム編集時
 // 大枠
@@ -236,55 +273,6 @@
 
 .btn-circle-flat:hover {
   background: red;
-}
-
-
-// -----キラッと光るアニメーション-----
-.shine-btn{
-  position: relative;
-  display:inline-block;
-    color: #fff;
-    text-decoration: none;
-    outline: none;
-    overflow: hidden;
-}
-
-.shine-btn::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -75%;
-    width: 50%;
-  height: 100%;
-  background: linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,.3) 100%);
-  transform: skewX(-25deg);
-}
-
-.shine-btn:hover::before {
-  animation: shine 0.7s;
-}
-
-@keyframes shine {
-  100% {
-    left: 125%;
-  }
-}
-
-// カードにホバーすると傾く
-.stacked--fan-right {
-	transform-origin: center bottom;
-
-	&:before,
-	&:after {
-			transform-origin: 50% 100%;
-	}
-
-	&:hover {
-			transform: translate(2.5px, 0) rotate(2.5deg);
-
-			&:before { transform: translate(-2.5px, 0) rotate(-2.5deg); }
-			&:after { transform: translate(-5px, 0) rotate(-5deg); }
-	}
 }
 
 

--- a/app/assets/stylesheets/tips.scss
+++ b/app/assets/stylesheets/tips.scss
@@ -7,28 +7,38 @@
 .tip-search-box {
 	padding: 25px 20px 0 20px;
 }
+// -----
+
 
 // ティップ一覧表示範囲
 .tip-index-box {
   background-color: #f8f9fa;
   height: 500px;
-  // height: auto;
 }
+// -----
 
+
+// ティップ新規登録フォーム
 .tip-new-form {
   margin-top: 100px;
 }
+// -----
+
 
 // 内容入力欄
 .tip-content .form-control {
   font-size: 1rem;
   height: 300px;
 }
+// -----
+
 
 // ティップ名入力欄
 .tip-name .form-control {
   width: 400px;
 }
+// -----
+
 
 // タグのフォーム
 .tip-tag {
@@ -74,6 +84,45 @@
   margin: 0;
 }
 
+.tip-show-box {
+  margin-top: 30px;
+}
+
+// ティップ詳細でのボタン
+.tip-show-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px 0;
+  padding: 0.5em 2em;
+  width: 250px;
+  color: #2285b1;
+  font-size: 1.2rem;
+  border: 2px solid #a0c4d3;
+  border-radius: 10px;
+}
+
+.tip-show-button::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-top: 3px solid #2285b1;
+  border-right: 3px solid #2285b1;
+  transform: rotate(45deg);
+}
+
+.tip-show-button:hover {
+  color: #333333;
+  text-decoration: none;
+  background-color: #a0c4d3;
+}
+
+.tip-show-button:hover::after {
+  border-top: 3px solid #333333;
+  border-right: 3px solid #333333;
+}
+// -----
+
 
 // 写真エリア
 .pictures-area {
@@ -99,23 +148,6 @@
   margin: 20px 10px;
 }
 
-// ティップ詳細画面
-.tip-show .edit-btn {
-  color: white;
-	font-weight: bold;
-  background-color: #8fbc8f;
-	display: block;
-	margin: 20px 0;
-	width: 200px;
-}
-
-.tip-show-box {
-  margin-top: 30px;
-}
-
-.tip-edit-btn {
-  margin: 0 20px;
-}
 
 // ティップ一覧画面でのカードデザイン
 .tip-index-box .card {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
   <% if controller.controller_name == 'tops' %>
     <%= yield %>
   <% else %>
-    <% unless controller.controller_name == 'tops' || controller.controller_name == 'registrations' || controller.controller_name == 'sessions' || controller.controller_name == 'helps' %>
+    <% unless controller.controller_name == 'tops' || controller.controller_name == 'registrations' || controller.controller_name == 'sessions' || controller.controller_name == 'helps' || controller.controller_name == 'passwords' %>
       <div id="sidebar">
         <div class="list">
           <div class="item header-title"></div>

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -18,7 +18,7 @@
   <%= form.label :チーム名 %>
   <%= form.text_field :name, class: 'form-control', placeholder: 'チーム名を入力して下さい。' %>
 
-  <% if controller.action_name == 'edit' %>
+  <% if controller.action_name == 'edit' || controller.action_name == 'update' %>
     <% if @team.members.count == 1 %>
       <div class="cp_ipradio">
         <div><%= form.label :使用用途 %></div>

--- a/app/views/teams/knowledges/show.html.erb
+++ b/app/views/teams/knowledges/show.html.erb
@@ -10,22 +10,22 @@
 </h1>
 
 <div class="knowledge-show">
-  <%= link_to team_knowledge_tips_path(@team.id, @knowledge.id), class: 'next-btn btn shine-btn' do %>
+  <%= link_to team_knowledge_tips_path(@team.id, @knowledge.id), class: 'knowledge-show-button' do %>
     <i class="fa fa-file-text"> ティップ</i>
   <% end %>
 
   <% if @stock.present? %>
-    <%= link_to team_knowledge_stock_path(@knowledge.team_id, @knowledge, params[:id]), method: :delete, class: 'stock-btn sad' do %>
+    <%= link_to team_knowledge_stock_path(@knowledge.team_id, @knowledge, params[:id]), method: :delete, class: 'knowledge-show-button sad' do %>
       <i class="fa fa-star"> ストック解除</i>
     <% end %>
   <% else %>
-    <%= link_to team_knowledge_stocks_path(@knowledge.team_id, @knowledge), method: :post, class: 'stock-btn fine' do %>
+    <%= link_to team_knowledge_stocks_path(@knowledge.team_id, @knowledge), method: :post, class: 'knowledge-show-button fine' do %>
       <i class="fa fa-star-o"> ストック登録</i>
     <% end %>
   <% end %>
 
   <% if @knowledge.member_id == @current_member.id %>
-    <%= link_to edit_team_knowledge_path(@team, @knowledge), class: 'edit-btn btn' do %>
+    <%= link_to edit_team_knowledge_path(@team, @knowledge), class: 'knowledge-show-button' do %>
       <i class="fa fa-pencil"> ナレッジ編集</i>
     <% end %>
   <% end %>

--- a/app/views/teams/knowledges/tips/show.html.erb
+++ b/app/views/teams/knowledges/tips/show.html.erb
@@ -40,7 +40,7 @@
 
 <div class="tip-show">
   <% if @tip.member.user.id == current_user.id %>
-    <%= link_to 'ティップ編集', edit_team_knowledge_tip_path(@team.id, @knowledge.id, @tip.id), class: 'edit-btn btn' %>
+    <%= link_to 'ティップ編集', edit_team_knowledge_tip_path(@team.id, @knowledge.id, @tip.id), class: 'tip-show-button' %>
   <% end %>
   <%= link_to '戻る', team_knowledge_tips_path, class: 'btn-flat-logo' %>
 </div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -9,49 +9,47 @@
   <%= @team.name %>
 </h1>
 
-<div class="team-show-function">
+<div class="team-show">
 
-  <div class="team-member-index">
+  <div class="team-show-function">
+    <%= link_to team_knowledges_path(@team), class: 'team-show-button' do %>
+      <i class="fa fa-folder-o"> ナレッジ</i>
+    <% end %>
+
+    <%= link_to team_tags_path(@team), class: 'team-show-button' do %>
+      <i class="fa fa-tag"> タグ</i>
+    <% end %>
+
+    <% if @team.is_solo? %>
+      <%= link_to team_group_path(@team.id, @team_message.id), class: 'team-show-button' do %>
+        <i class="fa fa-sticky-note"></i> メモ</i>
+      <% end %>
+    <% else %>
+      <%= link_to team_group_path(@team.id, @team_message.id), class: 'team-show-button' do %>
+        <i class="fa fa-comments"> チームメッセージ</i>
+      <% end %>
+    <% end %>
+
+    <% if current_user == @team.owner %>
+      <%= link_to edit_team_path(@team), class: 'team-show-button' do %>
+        <i class="fa fa-cogs"> チーム編集</i>
+      <% end %>
+    <% end%>
+  </div>
+
+  <div class="team-show-member">
     <p>メンバー</p>
       <ul>
-        <li class="team-show-li"><i class="fa fa-fort-awesome"></i><%= link_to @team.owner.username, team_member_path(@team.id, @owner.id) %></li>
+        <li class="team-show-li"><%= image_tag @team.owner.image.url if @team.owner.image && @team.owner.image.url %><%= link_to @team.owner.username, team_member_path(@team.id, @owner.id), class: 'member-button' %></li>
         <% @members.each do |member| %>
           <% if member.team.owner.id != member.user.id %>
-            <li class="team-show-li"><i class="fa fa-user"></i><%= link_to member.user.username, team_member_path(@team.id, member.id) %></li>
+            <li class="team-show-li"><%= image_tag member.user.image.url if member.user.image && member.user.image.url %><%= link_to member.user.username, team_member_path(@team.id, member.id), class: 'member-button' %></li>
           <% end %>
         <% end %>
       </ul>
     <%= paginate @members %>
   </div>
 
-  <div class="team-show">
-    <%= link_to team_knowledges_path(@team), class: 'next-btn btn shine-btn' do %>
-      <i class="fa fa-folder-o"> ナレッジ</i>
-    <% end %>
-
-    <%= link_to team_tags_path(@team), class: 'next-btn btn shine-btn' do %>
-      <i class="fa fa-tag"> タグ</i>
-    <% end %>
-
-    <% if @team.is_solo? %>
-      <%= link_to team_group_path(@team.id, @team_message.id), class: 'message-btn btn' do %>
-        <i class="fa fa-sticky-note"></i> メモ</i>
-      <% end %>
-    <% else %>
-      <%= link_to team_group_path(@team.id, @team_message.id), class: 'message-btn btn' do %>
-        <i class="fa fa-comments"> チームメッセージ</i>
-      <% end %>
-    <% end %>
-
-    <% if current_user == @team.owner %>
-      <%= link_to edit_team_path(@team), class: 'edit-btn btn' do %>
-        <i class="fa fa-pencil"> チーム編集</i>
-      <% end %>
-    <% end%>
-  </div>
-
 </div>
-
-<hr>
 
 <%= link_to '戻る', teams_path, class: 'btn-flat-logo' %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,8 +13,6 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-  config.action_mailer.default_url_options = { host: 'https://reco-reco.herokuapp.com/' }
-  config.action_mailer.delivery_method = :letter_opener_web
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.action_mailer.default_url_options = { host: 'https://reco-reco.herokuapp.com/' }
+  config.action_mailer.delivery_method = :letter_opener_web
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-
+  config.action_mailer.default_url_options = { host: 'https://reco-reco.herokuapp.com/' }
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true


### PR DESCRIPTION
## issue
close /#154

## 目的
まとまっていないため見にくい。

## 内容
・チーム詳細画面の全体的なデザインの調整
・ナレッジ詳細画面のボタンデザイン統一
・ティップ詳細画面のボタンデザイン統一
※　既読未読機能に不具合を発見してしまったので調整
※　チーム編集時、名前空欄のバリデーション発生で使用用途が表示されてしまっていた状態を修正

## 確認手順
画面の見やすさが向上したと思う。
実際メンター様にも見て頂いたが、良い方向に行っているとフィードバックを頂いた。
・チーム詳細、ナレッジ詳細、ティップ詳細画面確認
・チーム編集時、名前空更新で使用用途更新が表示されない
・既読未読が自分も含まれていた状態を修正
