### PR TITLE
ティップ詳細改善 

### DIFF
--- a/app/views/teams/knowledges/tips/show.html.erb
+++ b/app/views/teams/knowledges/tips/show.html.erb
@@ -18,7 +18,11 @@
 
   <h4 class="tip-show-label">内容</h4>
   <div class="tip-show-content">
-    <p><%= markdown(@tip.content).html_safe %></p>
+    <% if @tip.content.present? %>
+      <p><%= markdown(@tip.content).html_safe %></p>
+    <% else %>
+      <p>内容を入力して下さい。</p>
+    <% end %>
   </div>
 
   <h4 class="tip-show-label">タグ</h4>


### PR DESCRIPTION
## issue
close #159

## 目的
タイトルだけで内容を記述しないという状態を回避するため。

## 内容
内容を入力していない時に、入力するように促す文言を表示する設定を追加。

## 確認手順
・ティップをタイトルだけで登録し、詳細画面で確認可能。
