### PR TITLE
Team function fix

### DIFF
--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -15,7 +15,7 @@
   <%= form.hidden_field :user_id, value: current_user.id %>
   <%= form.hidden_field :owner_id, value: current_user.id %>
 
-  <%= form.label :チーム名 %>
+  <%= form.label :name, 'チーム名(30字以内)' %>
   <%= form.text_field :name, class: 'form-control', placeholder: 'チーム名を入力して下さい。' %>
 
   <% if controller.action_name == 'edit' || controller.action_name == 'update' %>


### PR DESCRIPTION
## issue
close #175

## 目的
UI改善

## 内容
文字入力制限(30字)を設定しているので、表示しないといけない。

## 確認手順
ユーザーが３０字以上で登録しようとする事がなくなる。
チームを作成、編集しようとする時に、名前を入力する際、ラベルを確認していただく。
