### PR TITLE
リファクタリングと動作調整

### DIFF
--- a/app/controllers/teams/groups_controller.rb
+++ b/app/controllers/teams/groups_controller.rb
@@ -14,19 +14,17 @@ class Teams::GroupsController < ApplicationController
     @team = Team.find(params[:team_id])
     @current_member = Member.find_by(team_id: @team.id, user_id: current_user.id)
     @group = Group.find(params[:id])
+    @message = Message.new
+    @messages = @group.messages.order(id: 'DESC')
+    @group_members = @group.group_members.page(params[:page]).per(10)
 
-    if GroupMember.where(member_id: @current_member.id, group_id: @group.id).present?
-      @messages = @group.messages.order(id: 'DESC')
-      @message = Message.new
-      @group_members = @group.group_members.page(params[:page]).per(10)
+    if Message.joins(:reads).find_by(reads: { is_checked: false }, reads: { member_id: @current_member.id }, group_id: @group.id).present?
 
-      @reads = Read.where(member_id: @current_member.id)
-        @reads.each do |read|
-          read.update(is_checked: true)
-        end
-# チャット画面を開いた時点で、Readテーブルにある自分のメンバーidにヒットするレコード(メッセージ)に既読としてis_checkedにtrueを入れる
-    else
-      redirect_to team_path(@team), notice: 'アクセスできません'
+      @unread_messages = Message.joins(:reads).where(reads: { is_checked: false }, reads: { member_id: @current_member.id }, group_id: @group.id)
+      @unread_messages.each do |message|
+        read = Read.find_by(member_id: @current_member.id, message_id: message.id)
+        read.update(is_checked: true)
+      end
     end
   end
 end


### PR DESCRIPTION
## issue
close #185

## 目的
・コードを読みやすくするため
・既読機能が正常に動作していなかったため

## 内容
・今の自分のメンバー情報を取得するロジックを調整

・メッセージのやりとりが見れる画面(group)を開くと未読のメッセージ(is_checked)がtrueになるロジックがある
①今の自分のメンバー情報
②今の自分のグループ
③メッセージが未読
のデータがあればその未読情報を既読にするように変更

## 確認手順
ユーザA：チームメッセージを投稿
ユーザA：ユーザBに対して投稿

ユーザB：チームメッセージを確認

ユーザA：チームメッセージにて既読１が付いている事を確認
ユーザA：ユーザBは個人メッセージを確認していないので個人メッセージには既読が付いていない確認