### PR TITLE
トップ画面のヘッダー調整

### DIFF
--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -111,27 +111,3 @@ p {
 .ms-auto {
   margin-left: auto !important;
 }
-
-@media (min-width: 768px) {
-  .container-md, .container-sm, .container {
-    max-width: 720px;
-  }
-}
-
-@media (min-width: 992px) {
-  .container-lg, .container-md, .container-sm, .container {
-    max-width: 960px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .container-xl, .container-lg, .container-md, .container-sm, .container {
-    max-width: 1140px;
-  }
-}
-
-@media (min-width: 1400px) {
-  .container-xxl, .container-xl, .container-lg, .container-md, .container-sm, .container {
-    max-width: 1320px;
-  }
-}

--- a/app/views/shared/layout/_header.html.erb
+++ b/app/views/shared/layout/_header.html.erb
@@ -1,16 +1,37 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container">
     <%= link_to 'Reco!', root_path, class: 'navbar-brand' %>
+
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+    </button>
+
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
         <% if user_signed_in? %>
           <li class="nav-item"><%= link_to I18n.t('views.messages.my_page'), user_path(current_user.id), class: 'nav-link active' %></li>
           <li class="nav-item"><%= link_to I18n.t('views.messages.log_out'), destroy_user_session_path, method: :delete, class: 'nav-link' %></li>
-          <li class="nav-item"><%= link_to 'ヘルプ', help_path, class: 'nav-link' %></li>
+          <% if controller.controller_name == 'helps' %>
+            <li class="nav-item"><%= link_to 'ヘルプ', help_path, class: 'nav-link active' %></li>
+          <% else %>
+            <li class="nav-item"><%= link_to 'ヘルプ', help_path, class: 'nav-link' %></li>
+          <% end %>
         <% else %>
-          <li class="nav-item"><%= link_to I18n.t('views.messages.sign_up'), new_user_registration_path, class: 'nav-link' %></li>
-          <li class="nav-item"><%= link_to I18n.t('views.messages.sign_in'), new_user_session_path, class: 'nav-link' %></li>
-          <li class="nav-item"><%= link_to 'ヘルプ', help_path, class: 'nav-link' %></li>
+          <% if controller.controller_name == 'registrations' %>
+            <li class="nav-item"><%= link_to I18n.t('views.messages.sign_up'), new_user_registration_path, class: 'nav-link active' %></li>
+          <% else %>
+            <li class="nav-item"><%= link_to I18n.t('views.messages.sign_up'), new_user_registration_path, class: 'nav-link' %></li>
+          <% end %>
+          <% if controller.controller_name == 'sessions' %>
+            <li class="nav-item"><%= link_to I18n.t('views.messages.sign_in'), new_user_session_path, class: 'nav-link active' %></li>
+          <% else %>
+            <li class="nav-item"><%= link_to I18n.t('views.messages.sign_in'), new_user_session_path, class: 'nav-link' %></li>
+          <% end %>
+          <% if controller.controller_name == 'helps' %>
+            <li class="nav-item"><%= link_to 'ヘルプ', help_path, class: 'nav-link active' %></li>
+          <% else %>
+            <li class="nav-item"><%= link_to 'ヘルプ', help_path, class: 'nav-link' %></li>
+          <% end %>
         <% end %>
       </ul>
     </div>


### PR DESCRIPTION
## issue
close #199 

## 目的
・画面縮小時に新規登録やログインのボタンが消えていたため
・今どの画面に居るのか active クラスを設定できていなかった

## 内容
・bootstrapのnavbarを設定した
・コントローラーごとにactiveクラスを付与する設定

## 確認手順
・画面縮小するとハンバーガーメニューになる
・新規登録画面などに遷移すると、ボタンがactive状態になる（色が着く）