### PR TITLE
top画面のボタン、画面縮小時の崩れを修正。

### DIFF
--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -1,4 +1,5 @@
-@charset "UTF-8";
+$white: white;
+$text: #094067;
 
 h1, .h1 {
   color: #094067;
@@ -78,17 +79,20 @@ p {
   text-align: center;
 }
 
-.text-white {
-  color: white;
+.main-content {
+  color: $white;
+  font-weight: 550;
+}
+
+.main-title {
+  color: $white;
+  font-size: 4rem;
+  font-weight: 550;
+  margin-bottom: 2rem;
 }
 
 .navbar-brand {
   font-size: 2.5rem;
-}
-
-#reco-main {
-  font-size: 4rem;
-  margin-bottom: 20px;
 }
 
 #scroll-to-top-btn{
@@ -107,7 +111,26 @@ p {
   transition-duration: 0.5s;
 }
 
-
 .ms-auto {
   margin-left: auto !important;
+}
+
+@media screen and (max-width: 600px) {
+  .top-btn {
+    font-size: .8rem;
+    padding: .8rem .8rem;
+    margin: 0 .4rem;
+  }
+
+  .main-title {
+    font-size: 3.5rem;
+  }
+
+  .main-content {
+    font-size: 1.5rem;
+  }
+
+  .navbar-brand {
+    font-size: 2rem;
+  }
 }

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -9,9 +9,9 @@
                     <span class="alert alert-error"><%= alert %></span>
                 <% end %>
             </div>
-            <h1 class="text-white fw-bolder" id="reco-main">Reco!</h1>
-            <h2 class="text-white fw-bolder">情報を記録・管理・共有できるアプリ</h2>
-            <h3 class="text-white">未来のために記録を残しましょう</h3>
+            <h1 class="main-title">Reco!</h1>
+            <h2 class="main-content">情報を記録・管理・共有できるアプリ</h2>
+            <h3 class="main-content">未来のために記録を残しましょう！</h3>
         </div>
     </div>
         <div class="text-center my-5">
@@ -106,7 +106,7 @@
 });
 
 
-ScrollReveal().reveal('#reco-main', {
+ScrollReveal().reveal('.main-title', {
     duration: 1600,
     scale: 4,
 });


### PR DESCRIPTION
## issue
close #201 

## 目的
スマホでの利用時、見た目が酷いため調整

## 内容
メディアクエリで調整

## 確認手順
画面を縮小してみて確認
トップページの新規登録やゲストログインのボタン