### PR TITLE
meta viewport の設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>Reco!</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <script src="https://unpkg.com/scrollreveal"></script>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">


### PR DESCRIPTION
## issue
close #208 

## 目的
レスポンシブ対応のためにviewportの設定を行う

## 内容
`<meta name="viewport" content="width=device-width,initial-scale=1">`

## 確認手順
スマホでアクセスしてみる
