### PR TITLE
トップ画面レスポンシブの見直し

### DIFF
--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -110,22 +110,6 @@ p {
   font-size: 1.5rem;
 }
 
-#scroll-to-top-btn{
-  position: fixed;
-  bottom: 20px;
-  right: 50px;
-  height: 50px;
-  width: 50px;
-  color: #FFF;
-  font-size: 2rem;
-  background-color: #9E9E9E;
-  border: none;
-  border-radius: 50%;
-  outline: none;
-  opacity: 0;
-  transition-duration: 0.5s;
-}
-
 .ms-auto {
   margin-left: auto !important;
 }
@@ -222,11 +206,7 @@ p {
 
 // -----explanation-----
   .top-function-explanation {
-    margin: 20px 0;
-
-    & h3 {
-      margin: 0 0 2rem 0;
-    }
+    margin: 0 0 50px 0;
 
     & p {
       line-height: 1;

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -22,7 +22,7 @@
     </div>
 </header>
 
-<section class="py-5">
+<section class="py-5 container">
     <div class="row justify-content-center">
         <div class="sub-content">
             <h2>日々行った事を、</h2>
@@ -37,21 +37,24 @@
 </section>
 
 <div class="py-2 bg-image-full">
-    <h2 class="top-function-num text-center text-white">機能①</h2>
-        <div class="top-function-explanation text-center justify-content-evenly row">
-            <div class="col-12 col-lg-6">
-                <h3 class="text-white">個人・チーム機能</h3>
-                <p class="text-white">簡単にチームを作成する事ができます。</p>
-                <p class="text-white">チームへの招待は、登録されたメールアドレスにより行います。</p>
+    <div class="container">
+        <h2 class="top-function-num text-center text-white">機能①</h2>
+            <div class="top-function-explanation text-center justify-content-evenly row">
+                <div class="col-12 col-lg-6">
+                    <h3 class="text-white">個人・チーム機能</h3>
+                    <p class="text-white">簡単にチームを作成する事ができます。</p>
+                    <p class="text-white">チームへの招待は、登録されたメールアドレスにより行います。</p>
+                </div>
+                <div class="col-12 col-lg-6">
+                    <%= image_tag 'top1.png', size: '500x350', class: 'rounded img-fluid' %>
+                </div>
             </div>
-            <div class="col-12 col-lg-6">
-                <%= image_tag 'top1.png', size: '500x350', class: 'rounded' %>
-            </div>
-        </div>
+    </div>
 </div>
 
 <div class="py-2 my-5 bg-image-full ">
-    <h2 class="top-function-num text-center text-white">機能②</h2>
+    <div class="container">
+        <h2 class="top-function-num text-center text-white">機能②</h2>
         <div class="top-function-explanation text-center justify-content-evenly row">
             <div class="col-12 col-lg-6">
                 <h3 class="text-white">メッセージ機能</h3>
@@ -60,13 +63,15 @@
                 <p class="text-white">すぐにメッセージでのやり取りが可能です。</p>
             </div>
             <div class="col-12 col-lg-6">
-                <%= image_tag 'top2.png', size: '500x350', class: 'rounded' %>
+                <%= image_tag 'top2.png', size: '500x350', class: 'rounded img-fluid' %>
             </div>
         </div>
+    </div>
 </div>
 
 <div class="py-2 my-5 bg-image-full ">
-    <h2 class="top-function-num text-center text-white">機能③</h2>
+    <div class="container">
+        <h2 class="top-function-num text-center text-white">機能③</h2>
         <div class="top-function-explanation text-center justify-content-evenly row">
             <div class="col-12 col-lg-6">
                 <h3 class="text-white">ナレッジ・ティップ機能</h3>
@@ -74,9 +79,10 @@
                 <p class="text-white">ティップを蓄積していきましょう。</p>
             </div>
             <div class="col-12 col-lg-6">
-                <%= image_tag 'top3.png', size: '500x350', class: 'rounded' %>
+                <%= image_tag 'top3.png', size: '500x350', class: 'rounded img-fluid' %>
             </div>
         </div>
+    </div>
 </div>
 
 <section class="py-5">
@@ -88,14 +94,12 @@
     </div>
 </section>
 
-<button id="scroll-to-top-btn"><i class="fa fa-arrow-up text-center"></i></button>
-
 <footer class="py-5 bg-dark">
     <div class="container"><p class="m-0 text-center text-white">Copyright &copy; Reco! 2021</p></div>
 </footer>
 
 <script>
-ScrollReveal().reveal('.top-function-explanation', {
+    ScrollReveal().reveal('.top-function-explanation', {
     duration: 1600,
     scale: 0.1,
 });
@@ -105,21 +109,4 @@ ScrollReveal().reveal('.main-title', {
     duration: 1600,
     scale: 4,
 });
-
-
-const scroll_to_top_btn = document.querySelector('#scroll-to-top-btn');
-
-scroll_to_top_btn.addEventListener( 'click' , scroll_to_top );
-function scroll_to_top(){
-    window.scroll({top: 0, behavior: 'smooth'});
-};
-
-window.addEventListener( 'scroll' , scroll_event );
-function scroll_event(){
-    if(window.pageYOffset > 400){
-    scroll_to_top_btn.style.opacity = '1';
-    }else if(window.pageYOffset < 400){
-    scroll_to_top_btn.style.opacity = '0';
-    }
-};
 </script>


### PR DESCRIPTION
## issue
close #210

## 目的
スマホ画面時に変な余白が表示されていたため、調整が必要

## 内容
ネガティブマージン？というものがあるらしく、それなのかなと思いつつ
https://www.yutaliberty.com/2019/04/18/prog/1624/

検証ツールで見た画面からはみ出している所の
rowをcontainerで囲っていなかったため、囲うことにより対応

また、下にスクロールしていくと上部へ簡単にスクロールできるボタンを用意していたが、
変な挙動の原因の一つだったため、今回以下の理由により削除した。
・興味本位で付けた機能でもあった
・実際は今のトップページは縦にそれほど長くもないので必要はないと判断

## 確認手順
スマホでアクセスしてみる
